### PR TITLE
Rust fmt and clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,7 +25,7 @@ dependencies = [
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -60,8 +60,8 @@ dependencies = [
 name = "dom"
 version = "0.1.0"
 dependencies = [
- "wasm-bindgen 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
- "web-sys 0.1.0 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen 0.2.22",
+ "web-sys 0.1.0",
  "wurst 0.1.0",
 ]
 
@@ -120,10 +120,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.2.6"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.7"
+source = "git+https://github.com/rustwasm/wasm-bindgen.git#9a1fa5a81b75807b03bee54907297560fd3a88d6"
 dependencies = [
- "wasm-bindgen 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen 0.2.22",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.2.7"
+dependencies = [
+ "wasm-bindgen 0.2.22",
 ]
 
 [[package]]
@@ -172,6 +179,7 @@ dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.22",
  "weedle 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -256,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -353,51 +361,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.21"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.22"
 dependencies = [
- "wasm-bindgen-macro 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen-macro 0.2.22",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.21"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.22"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen-shared 0.2.22",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.21"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.22"
 dependencies = [
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen-macro-support 0.2.22",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.21"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.22"
 dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
- "wasm-bindgen-shared 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen-backend 0.2.22",
+ "wasm-bindgen-shared 0.2.22",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.21"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
+version = "0.2.22"
 dependencies = [
  "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -406,7 +409,6 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-webidl"
 version = "0.2.17"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
 dependencies = [
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -415,21 +417,20 @@ dependencies = [
  "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen-backend 0.2.22",
  "weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
 version = "0.1.0"
-source = "git+https://github.com/rustwasm/wasm-bindgen.git#285c734a6a15fe3d9bf28922d1ed91ea2d30aa1d"
 dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.2.6 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "js-sys 0.2.7",
  "sourcefile 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
- "wasm-bindgen-webidl 0.2.17 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen 0.2.22",
+ "wasm-bindgen-webidl 0.2.17",
 ]
 
 [[package]]
@@ -450,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -467,7 +468,7 @@ name = "winapi-util"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -480,7 +481,7 @@ name = "wincolor"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -490,10 +491,10 @@ version = "0.1.0"
 dependencies = [
  "codegen 0.1.0",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.2.6 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "js-sys 0.2.7 (git+https://github.com/rustwasm/wasm-bindgen.git)",
  "sourcefile 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)",
- "web-sys 0.1.0 (git+https://github.com/rustwasm/wasm-bindgen.git)",
+ "wasm-bindgen 0.2.22",
+ "web-sys 0.1.0",
  "weedle 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -510,7 +511,7 @@ dependencies = [
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum js-sys 0.2.6 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
+"checksum js-sys 0.2.7 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
@@ -527,7 +528,7 @@ dependencies = [
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
-"checksum serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
+"checksum serde_json 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d30ec34ac923489285d24688c7a9c0898d16edff27fc1f1bd854edeff6ca3b7f"
 "checksum sourcefile 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "871c21c38541f347be1430fbb5134bd9200d9bfef4207ff5bb323e45025190d6"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9056ebe7f2d6a38bc63171816fd1d3430da5a43896de21676dc5c0a4b8274a11"
@@ -540,16 +541,9 @@ dependencies = [
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
 "checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
-"checksum wasm-bindgen 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum wasm-bindgen-backend 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum wasm-bindgen-macro 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum wasm-bindgen-macro-support 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum wasm-bindgen-shared 0.2.21 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum wasm-bindgen-webidl 0.2.17 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
-"checksum web-sys 0.1.0 (git+https://github.com/rustwasm/wasm-bindgen.git)" = "<none>"
 "checksum weedle 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4059f4341cd99b2434840996387570e38dc50239367e1aa35d2509fbb80aa76f"
 "checksum weedle 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26a4c67f132386d965390b8a734d5d10adbcd30eb5cc74bd9229af8b83f10044"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "wurst"
 description = "Webby UI Rust abstraction"
 license = "MIT OR Apache-2.0"
@@ -8,7 +9,6 @@ build = "build.rs"
 repository = "https://github.com/jonathanKingston/wurst"
 
 [workspace]
-
 members = [
     "crates/parser",
     "crates/codegen",
@@ -20,6 +20,10 @@ codegen = { path = "crates/codegen", version = "0.1" }
 sourcefile = "0.1"
 failure = "0.1.2"
 weedle = "0.6"
+
+[patch.'https://github.com/rustwasm/wasm-bindgen.git']
+wasm-bindgen = { path = "/home/jonathan/debugging/wasm-bindgen/" }
+web-sys = { path = "/home/jonathan/debugging/wasm-bindgen/crates/web-sys/" }
 
 [dependencies]
 wasm-bindgen = { git = 'https://github.com/rustwasm/wasm-bindgen.git' }

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,10 @@ use std::io::Write;
 use std::path::Path;
 
 use codegen::Codegen;
+#[macro_use]
 extern crate failure;
 use failure::ResultExt;
+use std::process::Command;
 
 fn main() -> Result<(), failure::Error> {
     let out_dir = env::var("OUT_DIR").context("reading OUT_DIR environment variable")?;
@@ -15,5 +17,14 @@ fn main() -> Result<(), failure::Error> {
     let dest_path = Path::new(&out_dir).join("bindings.rs");
     let mut f = File::create(&dest_path).unwrap();
     write!(f, "{}", codegen.get_code());
+
+    let status = Command::new("rustfmt")
+        .arg(&dest_path)
+        .status()
+        .context("running rustfmt")?;
+    if !status.success() {
+        bail!("rustfmt failed: {}", status)
+    }
+
     Ok(())
 }

--- a/crates/codegen/Cargo.toml
+++ b/crates/codegen/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "codegen"
 version = "0.1.0"
 authors = ["Jonathan Kingston <jonathan@jooped.co.uk>"]

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
@@ -26,9 +26,13 @@ impl Codegen {
                 let attr_name = field.to_string();
                 let set_name = "set_".to_string() + &attr_name;
                 let setter = Ident::new(&set_name, Span::call_site());
+                let setter_value = Ident::new(
+                    &format!("_{}_i_dont_care_about", set_name),
+                    Span::call_site(),
+                );
                 interface_calls.push(quote!{
                     if let Some(ref field) = self.#field_ident {
-                       #el.#setter(&field.clone());
+                       let #setter_value = #el.#setter(&field.clone());
                     }
                 });
             }
@@ -41,10 +45,10 @@ impl Codegen {
         let mut arms = vec![];
         let macro_name = Ident::new(&format!("console_{}", name), Span::call_site());
         let mut fn_name;
-        for i in (1..=7) {
+        for i in 1..=7 {
             fn_name = Ident::new(&format!("{}_{}", name, i), Span::call_site());
             let mut args = vec![];
-            for j in (1..=i) {
+            for j in 1..=i {
                 args.push(Ident::new(&format!("arg{}", j), Span::call_site()));
             }
             let args_u = args.clone();
@@ -82,7 +86,8 @@ impl Codegen {
 
     pub fn get_create_element_macro(&self) -> proc_macro2::TokenStream {
         let mut arms = vec![];
-        let mut macro_interfaces: Vec<(&str, &str)> = self.interfaces.tag_interfaces().into_iter().collect();
+        let mut macro_interfaces: Vec<(&str, &str)> =
+            self.interfaces.tag_interfaces().into_iter().collect();
         // Fallback for non named tags
         macro_interfaces.push(("$name".into(), "HTMLElementish".into()));
         for (tag, interface) in macro_interfaces {
@@ -104,7 +109,7 @@ impl Codegen {
                            $( $key: Some($value.into()), )*
                            ..Default::default()
                        };
-                       let el_container = El {
+                       let el_container = crate::El {
                            dom_node: None,
                            name: #tag_string.into(),
                            el: Some(el),
@@ -143,17 +148,15 @@ impl Codegen {
                 &Codegen::get_wurst_interface_name(interface),
                 Span::call_site(),
             );
-            let tag_ident = Ident::new(
-                &Codegen::enum_variant_from_tag_name(tag),
-                Span::call_site()
-            );
+            let tag_ident =
+                Ident::new(&Codegen::enum_variant_from_tag_name(tag), Span::call_site());
             interfaces.push(quote!{
-                #tag_ident(El<#ident>),
+                #tag_ident(Box<El<#ident>>),
             });
             froms.push(quote!{
                 impl From<El<#ident>> for InterfaceType {
                     fn from(t: El<#ident>) -> Self {
-                        InterfaceType::#tag_ident(t)
+                        InterfaceType::#tag_ident(Box::new(t))
                     }
                 }
             });
@@ -168,7 +171,7 @@ impl Codegen {
 
     pub fn get_interfaces_code(&self) -> Vec<proc_macro2::TokenStream> {
         let mut interfaces = vec![];
-        for (tag, interface) in &self.interfaces.tag_interfaces() {
+        for (_tag, interface) in &self.interfaces.tag_interfaces() {
             interfaces.push(self.get_interface_code(interface));
         }
         interfaces
@@ -193,31 +196,48 @@ impl Codegen {
 
     // Given an `interface_name` like `HTMLDivElement` append all the attribute names to the structs fields
     // Also construct the dyn_ref interface which will call `set_<attr_name>` when flush is called.
-    pub fn add_interface(&self, interface_name: &str, fields: &mut Vec<proc_macro2::TokenStream>, interfaces: &mut Vec<proc_macro2::TokenStream>) {
-        let code_interface_name = Ident::new(&Codegen::get_element_interface_name(interface_name), Span::call_site());
+    pub fn add_interface(
+        &self,
+        interface_name: &str,
+        fields: &mut Vec<proc_macro2::TokenStream>,
+        interfaces: &mut Vec<proc_macro2::TokenStream>,
+    ) {
+        let code_interface_name = Ident::new(
+            &Codegen::get_element_interface_name(interface_name),
+            Span::call_site(),
+        );
+        let flush_name = String::from(interface_name).to_lowercase() + "_flush";
+        let flush_interface_calls = Ident::new(&flush_name, Span::call_site());
         let interface_calls =
             self.method_calls(interface_name, Ident::new("iface_el", Span::call_site()));
-        interfaces.push(quote!{
-            {
-                let dyn_el: Option<&web_sys::#code_interface_name> = wasm_bindgen::JsCast::dyn_ref(&el);
-                dyn_el.map(|iface_el| {
-                    #(#interface_calls)*
-                });
-            }
-        });
+        if interface_calls.len() > 0 {
+            interfaces.push(quote!{
+                #[allow(clippy::let_unit_value)]
+                let #flush_interface_calls = |el: &web_sys::Node| {
+                    let dyn_el: Option<&web_sys::#code_interface_name> = wasm_bindgen::JsCast::dyn_ref(&*el);
+                    if let Some(iface_el) = dyn_el {
+                        #(#interface_calls)*
+                    }
+                };
+                #flush_interface_calls(&el);
+            });
+        }
         self.fields(interface_name, fields);
     }
 
     pub fn get_other_methods(&self, interface_name: &str) -> proc_macro2::TokenStream {
         // TODO save me from this hardcoded lifestyle
         let mut body = quote!{};
-        let code_interface_name = Ident::new(&Codegen::get_element_interface_name(interface_name), Span::call_site());
+        let code_interface_name = Ident::new(
+            &Codegen::get_element_interface_name(interface_name),
+            Span::call_site(),
+        );
 
-        if (interface_name == "HTMLInputElement") {
+        if interface_name == "HTMLInputElement" {
             body = quote!{
                 pub fn check_validity(&mut self) -> bool {
                     let el = self._node.take().unwrap();
-                    let mut r = {
+                    let r = {
                         let dyn_el: Option<&web_sys::#code_interface_name> = wasm_bindgen::JsCast::dyn_ref(&el);
                         dyn_el.map(|iface_el| {
                             iface_el.check_validity()
@@ -304,8 +324,7 @@ impl Codegen {
             #(#console_macro_code)*
 
             pub mod attr {
-                pub use Elementish;
-                pub use El;
+                pub use crate::{El, Elementish};
                 #enum_code
 
                 #(#interfaces)*

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "parser"
 version = "0.1.0"
 authors = ["Jonathan Kingston <jonathan@jooped.co.uk>"]
@@ -8,3 +9,4 @@ sourcefile = "0.1"
 failure = "0.1.2"
 weedle = "0.6"
 heck = "0.3"
+wasm-bindgen = { git = 'https://github.com/rustwasm/wasm-bindgen.git' }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -10,9 +10,10 @@ use sourcefile::SourceFile;
 use std::ffi::OsStr;
 use std::fs;
 
+extern crate wasm_bindgen;
+
 extern crate heck;
 use heck::SnakeCase;
-
 
 #[derive(Debug)]
 pub struct Interfaces {
@@ -48,7 +49,7 @@ impl Interfaces {
         interfaces.insert("p", "HTMLParagraphElement");
         interfaces.insert("html", "HTMLHtmlElement");
         interfaces.insert("font", "HTMLFontElement");
-/*
+        /*
 TODO interfaces:
 HTMLTableCellElement
 HTMLAnchorElement
@@ -131,7 +132,7 @@ HTMLTableCaptionElement
                                         continue;
                                     }
                                     // TODO handle native naming
-                                    if (a.identifier.0 == "type") {
+                                    if a.identifier.0 == "type" {
                                         continue;
                                     }
                                     let name = String::from(a.identifier.0).to_snake_case();
@@ -162,7 +163,6 @@ HTMLTableCaptionElement
     }
 
     pub fn get_methods(&self, interface_name: &str) -> Option<&Vec<String>> {
-      self.data.get(interface_name)
+        self.data.get(interface_name)
     }
-
 }

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -4,8 +4,8 @@ extern crate web_sys;
 
 #[macro_use]
 extern crate wurst;
-use wurst::El;
 use wurst::attr::*;
+use wurst::El;
 
 // Called by our JS entry point to run the example
 #[wasm_bindgen]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3279,12 +3279,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3299,17 +3301,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3426,7 +3431,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3438,6 +3444,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3452,6 +3459,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3563,7 +3571,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3575,6 +3584,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3696,6 +3706,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(extern_prelude)]
+#![feature(tool_lints)]
 extern crate wasm_bindgen;
 extern crate web_sys;
 
@@ -13,7 +13,9 @@ pub struct El<T: Elementish> {
 
 impl<A: Elementish> El<A> {
     pub fn create(&mut self) {
-        let el = web_sys::Window::document()
+        let el = web_sys::window()
+            .unwrap()
+            .document()
             .unwrap()
             .create_element(&self.name)
             .unwrap();
@@ -53,7 +55,8 @@ impl<A: Elementish> El<A> {
     /// Public interface that exposes concrete `Elementish` impl
     pub fn map<T>(&mut self, callback: T)
     where
-        T: Fn(A) -> A {
+        T: Fn(A) -> A,
+    {
         // TODO do something more graceful here for no el like creating one
         let mut interface = self.el.take().unwrap();
         interface.set_node(self.dom_node.take().unwrap());
@@ -67,7 +70,13 @@ impl<A: Elementish> El<A> {
     pub fn add_to_body(&mut self) {
         let maybe_el = self.dom_node.take();
         if let Some(el) = maybe_el {
-            let node: web_sys::Node = web_sys::Window::document().unwrap().body().unwrap().into();
+            let node: web_sys::Node = web_sys::window()
+                .unwrap()
+                .document()
+                .unwrap()
+                .body()
+                .unwrap()
+                .into();
             if let Ok(el) = node.append_child(&el) {
                 self.dom_node = Some(el);
             }
@@ -91,7 +100,7 @@ impl OutputConsole for bool {
     }
 }
 
-impl <'t> OutputConsole for &'t str {
+impl<'t> OutputConsole for &'t str {
     fn get_js_value(&self) -> wasm_bindgen::JsValue {
         wasm_bindgen::JsValue::from_str(&self)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 #[macro_use]
 extern crate wurst;
 // TODO generate a prelude
-use wurst::{Elementish, El, OutputConsole};
 use wurst::attr::*;
+use wurst::{El, OutputConsole};
 
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
-extern crate web_sys;
 extern crate js_sys;
+extern crate web_sys;
 
 #[wasm_bindgen]
 pub fn make() {


### PR DESCRIPTION
Boxing up the enum is the only real code change here. That and throwing the generated function calls into a closure called `flush_interface_calls`